### PR TITLE
Make --quiet also work when syncing

### DIFF
--- a/man/auracle.1.pod
+++ b/man/auracle.1.pod
@@ -50,7 +50,7 @@ This option defaults to 0 (no limit).
 
 =item B<--quiet>
 
-When used with the B<search> command, output will be limited to package names
+When used with the B<search> or B<sync> commands, output will be limited to package names
 only.
 
 =item B<-r>, B<--recurse>

--- a/src/auracle.cc
+++ b/src/auracle.cc
@@ -408,9 +408,12 @@ int Auracle::Sync(const std::vector<PackageOrDependency>& args) {
                                      return p.pkgname == r.name;
                                    });
           if (dlr::Pacman::Vercmp(r.version, iter->pkgver) > 0) {
-            printf("%s %s -> %s\n", terminal::Bold(r.name).c_str(),
-                   terminal::BoldRed(iter->pkgver).c_str(),
-                   terminal::BoldGreen(r.version).c_str());
+            if (options_.quiet)
+              printf("%s\n", r.name.c_str());
+            else
+              printf("%s %s -> %s\n", terminal::Bold(r.name).c_str(),
+                     terminal::BoldRed(iter->pkgver).c_str(),
+                     terminal::BoldGreen(r.version).c_str());
           }
         }
 
@@ -445,6 +448,7 @@ __attribute__((noreturn)) void usage(void) {
       "     --connect-timeout=N   Set connection timeout in seconds\n"
       "     --max-connections=N   Limit active connections\n"
       "     --color=WHEN          One of 'auto', 'never', or 'always'\n"
+      "     --quiet               Only display package names when searching or syncing\n"
       "\n"
       "Commands:\n"
       "  search\n"


### PR DESCRIPTION
Hello,

I'd like --quiet to also work when using `auracle sync`, as this is invaluable for scripting.
I don't know if this is the right approach, but `Auracle::Sync()` uses `printf()` instead of the `Format(Long|NameOnly|…)` like the other functions, so that's what I went with.

Cheers