### PR TITLE
WIP: Add a change directory flag for downloads

### DIFF
--- a/src/auracle.cc
+++ b/src/auracle.cc
@@ -486,7 +486,7 @@ __attribute__((noreturn)) void usage(void) {
       "\n"
       "  -q --quiet               Output less, when possible\n"
       "  -r --recurse             Recurse through dependencies on download\n"
-      "  -C --directory=PATH      Change directory before download\n"
+      "  -C DIR, --directory=DIR  Change directory before download\n"
       "     --literal             Disallow regex in searches\n"
       "     --searchby=BY         Change search-by dimension\n"
       "     --connect-timeout=N   Set connection timeout in seconds\n"

--- a/src/auracle.cc
+++ b/src/auracle.cc
@@ -2,6 +2,7 @@
 
 #include <getopt.h>
 #include <locale.h>
+#include <unistd.h>
 
 #include <functional>
 #include <memory>
@@ -367,9 +368,16 @@ void Auracle::IteratePackages(std::vector<PackageOrDependency> args,
 }
 
 int Auracle::Download(const std::vector<PackageOrDependency>& args,
-                      bool recurse) {
+                      bool recurse, std::optional<std::string> directory) {
   if (args.size() == 0) {
     return ErrorNotEnoughArgs();
+  }
+
+  if (directory.has_value()) {
+    if (chdir(directory.value().c_str()) != 0) {
+      std::cerr << "error: couldn't change directory" << std::endl;
+      return 1;
+    }
   }
 
   PackageIterator iter(recurse, /* download = */ true);
@@ -463,6 +471,7 @@ struct Flags {
   bool allow_regex = true;
   bool quiet = false;
   terminal::WantColor color = terminal::WantColor::AUTO;
+  std::optional<std::string> directory = std::nullopt;
 };
 
 __attribute__((noreturn)) void usage(void) {
@@ -476,6 +485,7 @@ __attribute__((noreturn)) void usage(void) {
       "\n"
       "  -q --quiet               Output less, when possible\n"
       "  -r --recurse             Recurse through dependencies on download\n"
+      "  -C --directory=PATH      Change directory before download\n"
       "     --literal             Disallow regex in searches\n"
       "     --searchby=BY         Change search-by dimension\n"
       "     --connect-timeout=N   Set connection timeout in seconds\n"
@@ -512,6 +522,7 @@ bool ParseFlags(int* argc, char*** argv, Flags* flags) {
       { "help",              no_argument,       0, 'h' },
       { "quiet",             no_argument,       0, 'q' },
       { "recurse",           no_argument,       0, 'r' },
+      { "directory",         required_argument, 0, 'C' },
 
       { "color",             required_argument, 0, COLOR },
       { "connect-timeout",   required_argument, 0, CONNECT_TIMEOUT },
@@ -535,7 +546,7 @@ bool ParseFlags(int* argc, char*** argv, Flags* flags) {
   };
 
   int opt, optidx;
-  while ((opt = getopt_long(*argc, *argv, "hqr", opts, &optidx)) != -1) {
+  while ((opt = getopt_long(*argc, *argv, "hqrC:", opts, &optidx)) != -1) {
     std::string_view sv_optarg(optarg);
 
     switch (opt) {
@@ -546,6 +557,9 @@ bool ParseFlags(int* argc, char*** argv, Flags* flags) {
         break;
       case 'r':
         flags->recurse = true;
+        break;
+      case 'C':
+        flags->directory = std::string(sv_optarg);
         break;
       case LITERAL:
         flags->allow_regex = false;
@@ -637,7 +651,7 @@ int main(int argc, char** argv) {
   } else if (action == "info") {
     return auracle.Info(args);
   } else if (action == "download") {
-    return auracle.Download(args, flags.recurse);
+    return auracle.Download(args, flags.recurse, flags.directory);
   } else if (action == "sync") {
     return auracle.Sync(args);
   } else if (action == "buildorder") {

--- a/src/auracle.cc
+++ b/src/auracle.cc
@@ -337,7 +337,8 @@ void Auracle::IteratePackages(std::vector<PackageOrDependency> args,
                     return 1;
                   }
 
-                  std::cout << "download complete: " << pwd_.get() << "/"
+                  std::cout << "download complete: "
+                            << getcwd(nullptr, 0) << "/"
                             << pkgbase << std::endl;
                   return ExtractArchive(response.value().archive_bytes);
                 });

--- a/src/auracle.hh
+++ b/src/auracle.hh
@@ -87,7 +87,8 @@ class Auracle {
   int Info(const std::vector<PackageOrDependency>& args);
   int Search(const std::vector<PackageOrDependency>& args,
              aur::SearchRequest::SearchBy by);
-  int Download(const std::vector<PackageOrDependency>& args, bool recurse);
+  int Download(const std::vector<PackageOrDependency>& args, bool recurse,
+               std::optional<std::string> directory);
   int Sync(const std::vector<PackageOrDependency>& args);
   int BuildOrder(const std::vector<PackageOrDependency>& args);
 

--- a/src/auracle.hh
+++ b/src/auracle.hh
@@ -74,8 +74,7 @@ class Auracle {
       : options_(std::move(options)),
         aur_(options_.aur_baseurl),
         allow_regex_(options_.allow_regex),
-        pacman_(options_.pacman),
-        pwd_(getcwd(nullptr, 0)) {
+        pacman_(options_.pacman) {
     aur_.SetMaxConnections(options_.max_connections);
     aur_.SetConnectTimeout(options_.connection_timeout);
   }


### PR DESCRIPTION
This adds a flag in the spirit of the `-C` option as seen in `tar`. Setting it will change the current directory before downloading packages.

This is marked as WIP because the wrong directory is printed after the download is complete, namely the one we started in, with the package base name appended. From what I can tell it happens because the corresponding class is initialized with the current directory in a member and that member is accessed. Is there a reason for this pattern instead of just printing the current directory when needed?

edit: Also, how do you prefer the new option to be printed? This is the first time there's a short and long option with a required argument, so listing it twice could work.

edit: I discovered https://en.cppreference.com/w/cpp/filesystem is a thing. Using it might make the code clearer, but this is using exceptions while the rest of the codebase uses integer error codes.