### PR TITLE
Add verbose mode and print everything in sync mode

### DIFF
--- a/man/auracle.1.pod
+++ b/man/auracle.1.pod
@@ -53,6 +53,12 @@ This option defaults to 5.
 When used with the B<search> and B<sync> commands, output will be limited to
 package names only.
 
+=item B<-v>I<N>, B<--verbose=>I<N>
+
+Enable verbose output mode. Without an argument, increases verbosity level
+by 1. With an argument, sets verbosity to that level. In B<sync>, causes
+all packages to be printed, not just those needing an update.
+
 =item B<-r>, B<--recurse>
 
 When used with the B<download> command, recursively follow and download

--- a/src/auracle/auracle.cc
+++ b/src/auracle/auracle.cc
@@ -573,14 +573,13 @@ int Auracle::Sync(const std::vector<std::string>& args,
           auto iter = std::find_if(
               foreign_pkgs.cbegin(), foreign_pkgs.cend(),
               [&r](const Pacman::Package& p) { return p.pkgname == r.name; });
-          if (Pacman::Vercmp(r.version, iter->pkgver) > 0) {
-            if (options.quiet) {
-              std::cout << format::NameOnly(r);
-            } else {
-              std::cout << format::Update(*iter, r,
-                                          pacman_->ShouldIgnorePackage(r.name));
-            }
-          }
+
+          auto needs_update = Pacman::Vercmp(r.version, iter->pkgver) > 0;
+          if (needs_update && options.quiet)
+            std::cout << format::NameOnly(r);
+          else if (needs_update || options.verbosity > 0)
+            std::cout << format::Update(*iter, r,
+                                        pacman_->ShouldIgnorePackage(r.name), needs_update);
         }
 
         return 0;

--- a/src/auracle/auracle.hh
+++ b/src/auracle/auracle.hh
@@ -67,6 +67,7 @@ class Auracle {
     bool recurse = false;
     bool allow_regex = true;
     bool quiet = false;
+    int  verbosity = 0;
     sort::Sorter sorter =
         sort::MakePackageSorter("name", sort::OrderBy::ORDER_ASC);
   };

--- a/src/auracle/format.cc
+++ b/src/auracle/format.cc
@@ -281,8 +281,17 @@ std::ostream& operator<<(std::ostream& os, const Long& l) {
 std::ostream& operator<<(std::ostream& os, const Update& u) {
   namespace t = terminal;
 
-  os << t::Bold(u.from.pkgname) << " " << t::BoldRed(u.from.pkgver) << " -> "
-     << t::BoldGreen(u.to.version) << (u.ignored ? " [ignored]" : "") << "\n";
+  os << t::Bold(u.from.pkgname) << " ";
+
+  if (u.needs_update)
+    os << t::BoldRed(u.from.pkgver) << " -> " << t::BoldGreen(u.to.version);
+  else
+    os << t::BoldGreen(u.from.pkgver);
+
+  if (u.ignored)
+    os << " [ignored]";
+
+  os << "\n";
 
   return os;
 }

--- a/src/auracle/format.hh
+++ b/src/auracle/format.hh
@@ -45,8 +45,8 @@ struct Long {
 
 struct Update {
   Update(const auracle::Pacman::Package& from, const aur::Package& to,
-         bool ignored)
-      : from(from), to(to), ignored(ignored) {}
+         bool ignored, bool needs_update)
+      : from(from), to(to), ignored(ignored), needs_update(needs_update) {}
 
   friend std::ostream& operator<<(std::ostream& os, const Update& u);
 
@@ -54,6 +54,7 @@ struct Update {
   const auracle::Pacman::Package& from;
   const aur::Package& to;
   const bool ignored;
+  const bool needs_update;
 };
 
 }  // namespace format


### PR DESCRIPTION
This adds a verbose command line option (similar to many other command line utilities). When running in verbose mode, the `sync` command will print out all packages and their versions, not just the packages that need updating.

I wasn't exactly sure how verbose mode and quiet mode should interact. I set quiet mode to trump verbose mode.

The impetus for this change was that I wanted to see some output when I ran `auracle sync` when there were no updates. I figured that a `--verbose` setting was more general and might be useful in other places as well.

Also, `from_chars` is supported for integral types as of GCC 8 and Clang 7.0.0, so I used that since it fits the best with `string_view` (everything else requires a null-terminated string or `std::string const&`).