### PR TITLE
Removed redudant space from Update format

### DIFF
--- a/src/auracle/format.cc
+++ b/src/auracle/format.cc
@@ -215,7 +215,7 @@ void Update(const auracle::Pacman::Package& from, const aur::Package& to,
             bool ignored) {
   namespace t = terminal;
 
-  fmt::print("{} {} -> {} {}\n", t::Bold(from.pkgname), t::BoldRed(from.pkgver),
+  fmt::print("{} {} -> {}{}\n", t::Bold(from.pkgname), t::BoldRed(from.pkgver),
              t::BoldGreen(to.version), ignored ? " [ignored]" : "");
 }
 


### PR DESCRIPTION
Update format would output one space too many after the to version:
- for not ignored packages it output one space followed by a terminating newline
- for ignored packages it output two spaces
It only needs to output one space for ignored packages and none for not ignored packages.