### PR TITLE
Fix mismatched free in UrlEscape

### DIFF
--- a/src/aur/request.cc
+++ b/src/aur/request.cc
@@ -13,7 +13,7 @@ namespace {
 std::string UrlEscape(const std::string_view sv) {
   char* ptr = curl_easy_escape(nullptr, sv.data(), sv.size());
   std::string escaped(ptr);
-  free(ptr);
+  curl_free(ptr);
 
   return escaped;
 }


### PR DESCRIPTION
This fixes a crash with the latest `curl 7.64.0-5` in `testing`. See https://curl.haxx.se/libcurl/c/curl_easy_escape.html.

I haven't checked, but there might be other mismatched `free()` calls.