### PR TITLE
Add install status to search

### DIFF
--- a/src/auracle/auracle.cc
+++ b/src/auracle/auracle.cc
@@ -40,9 +40,11 @@ void FormatNameOnly(const std::vector<aur::Package>& packages) {
   }
 }
 
-void FormatShort(const std::vector<aur::Package>& packages) {
+void FormatShort(const std::vector<aur::Package>& packages,
+                const auracle::Pacman* pacman) {
   for (const auto& p : packages) {
-    format::Short(p);
+    auto local_pkg = pacman->GetLocalPackage(p.name);
+    format::Short(p, local_pkg ? &local_pkg.value() : nullptr);
   }
 }
 
@@ -382,7 +384,7 @@ int Auracle::Search(const std::vector<std::string>& args,
   } else if (options.quiet) {
     FormatNameOnly(packages);
   } else {
-    FormatShort(packages);
+    FormatShort(packages, pacman_);
   }
 
   return 0;

--- a/src/auracle/format.cc
+++ b/src/auracle/format.cc
@@ -143,17 +143,28 @@ void NameOnly(const aur::Package& package) {
   fmt::print(terminal::Bold("{}\n"), package.name);
 }
 
-void Short(const aur::Package& package) {
+void Short(const aur::Package& package,
+          const auracle::Pacman::Package* local_package) {
   namespace t = terminal;
 
+  const auto l = local_package;
   const auto& p = package;
   const auto ood_color = p.out_of_date > std::chrono::seconds::zero()
                              ? &t::BoldRed
                              : &t::BoldGreen;
 
-  fmt::print("{}{} {} ({}, {})\n    {}\n", t::BoldMagenta("aur/"),
+  std::string installed_package;
+  if (l != nullptr) {
+    const auto local_ver_color =
+        auracle::Pacman::Vercmp(l->pkgver, p.version) < 0 ? &t::BoldRed
+                                                          : &t::BoldGreen;
+    installed_package =
+        fmt::format("[installed: {}]", local_ver_color(l->pkgver));
+  }
+
+  fmt::print("{}{} {} ({}, {}) {}\n    {}\n", t::BoldMagenta("aur/"),
              t::Bold(p.name), ood_color(p.version), p.votes, p.popularity,
-             p.description);
+             installed_package, p.description);
 }
 
 void Long(const aur::Package& package,

--- a/src/auracle/format.hh
+++ b/src/auracle/format.hh
@@ -10,7 +10,8 @@ namespace format {
 
 void NameOnly(const aur::Package& package);
 void Update(const auracle::Pacman::Package& from, const aur::Package& to);
-void Short(const aur::Package& package);
+void Short(const aur::Package& package,
+          const auracle::Pacman::Package* local_package);
 void Long(const aur::Package& package,
           const auracle::Pacman::Package* local_package);
 void Custom(const std::string& format, const aur::Package& package);

--- a/tests/sort.py
+++ b/tests/sort.py
@@ -25,7 +25,7 @@ class SortTest(auracle_test.TestCase):
         v = []
         for line in p.stdout.decode().splitlines():
             if line.startswith('Popularity'):
-                v.append(float(line.rsplit(':')[-1].strip()))
+                v.append(float(line.rsplit(':')[-3].strip()))
 
         self.assertTrue(all(v[i] >= v[i+1] for i in range(len(v) -1)))
 
@@ -38,7 +38,7 @@ class SortTest(auracle_test.TestCase):
         v = []
         for line in p.stdout.decode().splitlines():
             if line.startswith('aur/'):
-                v.append(int(line.split()[-2][1:-1]))
+                v.append(int(line.split()[2][1:-1]))
 
         self.assertTrue(all(v[i] <= v[i+1] for i in range(len(v) -1)))
 
@@ -51,7 +51,7 @@ class SortTest(auracle_test.TestCase):
         v = []
         for line in p.stdout.decode().splitlines():
             if line.startswith('aur/'):
-                v.append(int(line.split()[-2][1:-1]))
+                v.append(int(line.split()[2][1:-1]))
 
         self.assertTrue(all(v[i] >= v[i+1] for i in range(len(v) -1)))
 


### PR DESCRIPTION
Output follows the same format and colouring as info:

```   
aur/auracle-git r192.ad01c04-2 (24, 6.56497) [installed: r202.225d9b9-1]
    A flexible client for the AUR
```

Fixes #8