### PR TITLE
Strip IgnorePkg handling per #44

### DIFF
--- a/src/auracle/auracle.cc
+++ b/src/auracle/auracle.cc
@@ -202,10 +202,6 @@ void Auracle::IteratePackages(std::vector<std::string> args,
   aur::InfoRequest info_request;
 
   for (const auto& arg : args) {
-    if (pacman_->ShouldIgnorePackage(arg)) {
-      continue;
-    }
-
     if (state->package_cache.LookupByPkgname(arg) != nullptr) {
       continue;
     }
@@ -614,7 +610,7 @@ int Auracle::Sync(const std::vector<std::string>& args,
             if (options.quiet) {
               format::NameOnly(r);
             } else {
-              format::Update(*iter, r, pacman_->ShouldIgnorePackage(r.name));
+              format::Update(*iter, r);
             }
           }
         }

--- a/src/auracle/format.cc
+++ b/src/auracle/format.cc
@@ -211,12 +211,11 @@ void Long(const aur::Package& package,
   fmt::print("\n");
 }
 
-void Update(const auracle::Pacman::Package& from, const aur::Package& to,
-            bool ignored) {
+void Update(const auracle::Pacman::Package& from, const aur::Package& to) {
   namespace t = terminal;
 
-  fmt::print("{} {} -> {}{}\n", t::Bold(from.pkgname), t::BoldRed(from.pkgver),
-             t::BoldGreen(to.version), ignored ? " [ignored]" : "");
+  fmt::print("{} {} -> {}\n", t::Bold(from.pkgname), t::BoldRed(from.pkgver),
+             t::BoldGreen(to.version));
 }
 
 void FormatCustomTo(std::string* out, const std::string& format,

--- a/src/auracle/format.hh
+++ b/src/auracle/format.hh
@@ -9,8 +9,7 @@
 namespace format {
 
 void NameOnly(const aur::Package& package);
-void Update(const auracle::Pacman::Package& from, const aur::Package& to,
-            bool ignored);
+void Update(const auracle::Pacman::Package& from, const aur::Package& to);
 void Short(const aur::Package& package);
 void Long(const aur::Package& package,
           const auracle::Pacman::Package* local_package);

--- a/src/auracle/pacman.cc
+++ b/src/auracle/pacman.cc
@@ -46,10 +46,9 @@ bool IsSection(const std::string& s) {
 
 namespace auracle {
 
-Pacman::Pacman(alpm_handle_t* alpm, std::vector<std::string> ignored_packages)
+Pacman::Pacman(alpm_handle_t* alpm)
     : alpm_(alpm),
-      local_db_(alpm_get_localdb(alpm_)),
-      ignored_packages_(std::move(ignored_packages)) {}
+      local_db_(alpm_get_localdb(alpm_)) {}
 
 Pacman::~Pacman() { alpm_release(alpm_); }
 
@@ -59,7 +58,6 @@ struct ParseState {
   std::string rootdir = "/";
 
   std::string section;
-  std::vector<std::string> ignorepkgs;
   std::vector<std::string> repos;
 };
 
@@ -92,12 +90,7 @@ bool ParseOneFile(const std::string& path, ParseState* state) {
     trim(&value);
 
     if (state->section == "options") {
-      if (key == "IgnorePkg") {
-        std::istringstream iss(value);
-        std::copy(std::istream_iterator<std::string>(iss),
-                  std::istream_iterator<std::string>(),
-                  std::back_inserter(state->ignorepkgs));
-      } else if (key == "DBPath") {
+      if (key == "DBPath") {
         state->dbpath = value;
       } else if (key == "RootDir") {
         state->rootdir = value;
@@ -145,15 +138,7 @@ std::unique_ptr<Pacman> Pacman::NewFromConfig(const std::string& config_file) {
                          static_cast<alpm_siglevel_t>(0));
   }
 
-  return std::unique_ptr<Pacman>(
-      new Pacman(state.alpm, std::move(state.ignorepkgs)));
-}
-
-bool Pacman::ShouldIgnorePackage(const std::string& package) const {
-  return std::find_if(ignored_packages_.cbegin(), ignored_packages_.cend(),
-                      [&package](const std::string& p) {
-                        return fnmatch(p.c_str(), package.c_str(), 0) == 0;
-                      }) != ignored_packages_.cend();
+  return std::unique_ptr<Pacman>(new Pacman(state.alpm));
 }
 
 std::string Pacman::RepoForPackage(const std::string& package) const {

--- a/src/auracle/pacman.hh
+++ b/src/auracle/pacman.hh
@@ -32,9 +32,6 @@ class Pacman {
 
   static int Vercmp(const std::string& a, const std::string& b);
 
-  // Returns true if the package is ignored.
-  bool ShouldIgnorePackage(const std::string& package) const;
-
   // Returns the name of the repo that the package belongs to, or empty string
   // if the package was not found in any repo.
   std::string RepoForPackage(const std::string& package) const;
@@ -52,12 +49,10 @@ class Pacman {
   std::optional<Package> GetLocalPackage(const std::string& name) const;
 
  private:
-  Pacman(alpm_handle_t* alpm, std::vector<std::string> ignored_packages);
+  Pacman(alpm_handle_t* alpm);
 
   alpm_handle_t* alpm_;
   alpm_db_t* local_db_;
-
-  std::vector<std::string> ignored_packages_;
 };
 
 }  // namespace auracle


### PR DESCRIPTION
Generally, if folks are using an AUR helper to download a specific
package, they don't care if it's being ignored by pacman or pacman
wrappers.

See #44 for further discussion.