### PR TITLE
meson.build: added more libsystemd dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -76,7 +76,7 @@ libauracle = static_library(
       'src',
     ],
     link_with : [libaur],
-    dependencies : [libalpm, libarchive, libfmt, stdcppfs])
+    dependencies : [libalpm, libarchive, libfmt, stdcppfs, libsystemd])
 
 auracle = executable(
     'auracle',
@@ -85,7 +85,8 @@ auracle = executable(
       'src',
     ],
     link_with : [libauracle],
-    install : true)
+    install : true,
+    dependencies : libsystemd)
 
 man = custom_target(
     'man',


### PR DESCRIPTION
**EDIT:**
This commit will now add libsystemd as dependencies for both
libauracle library and auracle executable.

By doing so, when there's a libsystemd pkg config file
meson will grab CFLAGS containing a reference
to includedir path. This will allow elogind users to be
able to successfully build the package

**Original:**
This commit will create a `systemdir` variable that use includedir
variable from libsystemd pkgconfig.

This will allow **libelogind** users to be able successfully build
and test the package even with `#Include <systemd/*.h>` as those
headers are residing in `/usr/include/elogind`