### PR TITLE
unbreak meson wrap for fmt due to nonexisting domain

### DIFF
--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -5,6 +5,6 @@ source_url = https://github.com/fmtlib/fmt/archive/6.0.0.tar.gz
 source_filename = fmt-6.0.0.tar.gz
 source_hash = f1907a58d5e86e6c382e51441d92ad9e23aea63827ba47fd647eacc0d3a16c78
 
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/fmt/6.0.0/1/get_zip
+patch_url = https://github.com/mesonbuild/fmt/releases/download/6.0.0-1/fmt.zip
 patch_filename = fmt-6.0.0-1-wrap.zip
 patch_hash = b514ead73cd8d535ebe627473093e75b439afc1f3b58e038408c2e7d6da998c3


### PR DESCRIPTION
The wrapdb is a pile of... unreliability, and it keeps going down. The only thing it does anyway is serve as a redirection service to the files which are really stored on Github, but "we need our own domain, it's more reliable if we ever move away from Github". The problem is that this logic is all backwards -- the custom domain is the unreliable thing here. In the latest instance:

- "It seems that I lost that server entirely."
- "... you lost it?!"
- "well, it was a VM on a server of my ex-ex-ex-ex-boss and apparently he did something with it and I don't have access there anymore."

So let's not trust wrapdb to ever be reliable, and instead download wrap patches from github which is very reliable. In the supremely unlikely situation that meson not only moves away from github but nukes all their old data from high orbit, we can just update this again.