### PR TITLE
Fix infinite loop in AurImpl::Wait

### DIFF
--- a/src/aur/aur.cc
+++ b/src/aur/aur.cc
@@ -302,7 +302,8 @@ int AurImpl::SocketCallback(CURLM*, curl_socket_t s, int action, void* userdata,
 int AurImpl::DispatchSocketCallback(curl_socket_t s, int action,
                                     sd_event_source* io) {
   if (action == CURL_POLL_REMOVE) {
-    return FinishRequest(io);
+    sd_event_source_unref(io);
+    return CheckFinished();
   }
 
   auto events = [action]() -> std::uint32_t {


### PR DESCRIPTION
Fixes #73

When receiving CURL_POLL_REMOVE from libcurl, we calls FinishRequest
with the sd_event_source handle, which would try to remove the
sd_event_source handle from active_requests_. Yet the only
sd_event_source handles stored in active_requests_ are the handles for
git child processes. Essentially we are trying to remove the wrong
handles, which leave completed requests in active_requests_, causing
Wait() to loop forever (or until timeout).

This commits add a call to CheckFinished() in that case to make sure no
completed curl requests are left in active_requests_, which fixes this
problem.

Signed-off-by: Yuxuan Shui <yshuiv7@gmail.com>