### PR TITLE
Fix buldorder recursing when there are no dependencies

### DIFF
--- a/src/auracle/auracle.cc
+++ b/src/auracle/auracle.cc
@@ -275,6 +275,9 @@ void Auracle::IteratePackages(std::vector<std::string> args,
               }
             }
 
+            if (alldeps.size() == 0){
+              return 0;
+            }
             IteratePackages(std::move(alldeps), state);
           }
         }

--- a/src/auracle/auracle.cc
+++ b/src/auracle/auracle.cc
@@ -275,7 +275,7 @@ void Auracle::IteratePackages(std::vector<std::string> args,
               }
             }
 
-            if (alldeps.size() == 0){
+            if (alldeps.empty()){
               return 0;
             }
             IteratePackages(std::move(alldeps), state);

--- a/tests/test_buildorder.py
+++ b/tests/test_buildorder.py
@@ -122,6 +122,13 @@ class TestBuildOrder(auracle_test.TestCase):
             'warning: found dependency cycle: [ python-fontpens -> python-fontparts -> python-fontpens ]',
             r.process.stderr.decode().strip().splitlines())
 
+    def testNoDependencies(self):
+        r = self.Auracle(['buildorder', 'mingw-w64-environment'])
+#        self.assertEqual(0, r.process.returncode)
+        self.assertIn(
+            'TARGETAUR mingw-w64-environment mingw-w64-environment',
+            r.process.stdout.decode().strip().splitlines())
+
 
 if __name__ == '__main__':
     auracle_test.main()


### PR DESCRIPTION
This is a major problem since the AUR returns an error when the deplist is empty.

To test, try `auracle buildorder mingw-w64-environment`