### PR TITLE
Correct the closing quotation for the proxy flag ZSH completion

### DIFF
--- a/extra/zsh_completion
+++ b/extra/zsh_completion
@@ -16,7 +16,7 @@ _arguments -S \
   '(--sort)--rsort=[Sort results in descending order]: :(name popularity votes firstsubmitted lastmodified)' \
   '--resolve-deps=[Control depends resolution]: :(depends checkdepends makedepends)' \
   "--show-file=[File to dump with 'show' command]" \
-  '--proxy=[Specifies the URL to a proxy server]" \
+  '--proxy=[Specifies the URL to a proxy server]' \
   '(-): :->command' \
   '*:: :->option-or-argument'
 


### PR DESCRIPTION
ZSH completion started failing on Arch recently, despite this mismatch quote having been here since the second latest commit for a while now. Locally, correcting this quote fixes the ZSH completion.